### PR TITLE
Add status config

### DIFF
--- a/app/models/stuff_to_do.rb
+++ b/app/models/stuff_to_do.rb
@@ -167,6 +167,14 @@ class StuffToDo < ActiveRecord::Base
     reorder_projects(user, project_ids)
   end
 
+  def self.available_status?(issue)
+    ( Setting.plugin_stuff_to_do_plugin['statuses_for_stuff_to_do'] & ['all', issue.status] ).size > 0
+  end
+
+  def self.unavailable_status?(issue)
+    !self.available_status?(issue)
+  end
+
   private
 
   def self.reorder_issues(user, issue_ids)

--- a/app/models/stuff_to_do.rb
+++ b/app/models/stuff_to_do.rb
@@ -249,7 +249,9 @@ class StuffToDo < ActiveRecord::Base
   def self.conditions_for_available(user, filter_by, project)
     scope = self
     conditions = "#{IssueStatus.table_name}.is_closed = false"
-    conditions << " AND (#{IssueStatus.table_name}.id IN (#{Setting.plugin_stuff_to_do_plugin['statuses_for_stuff_to_do'].join(',')}))"
+    unless Setting.plugin_stuff_to_do_plugin['statuses_for_stuff_to_do'].include? 'all'
+      conditions << " AND (#{IssueStatus.table_name}.id IN (#{Setting.plugin_stuff_to_do_plugin['statuses_for_stuff_to_do'].join(',')}))"
+    end
     conditions << " AND (" << "#{Project.table_name}.status = %d" % [Project::STATUS_ACTIVE] << ")"
     conditions << " AND ((" << "assigned_to_id = %d" % [user.id] << ")"
     if(user.is_a?(User))

--- a/app/models/stuff_to_do.rb
+++ b/app/models/stuff_to_do.rb
@@ -249,6 +249,7 @@ class StuffToDo < ActiveRecord::Base
   def self.conditions_for_available(user, filter_by, project)
     scope = self
     conditions = "#{IssueStatus.table_name}.is_closed = false"
+    conditions << " AND (#{IssueStatus.table_name}.id IN (#{Setting.plugin_stuff_to_do_plugin['statuses_for_stuff_to_do'].join(',')}))"
     conditions << " AND (" << "#{Project.table_name}.status = %d" % [Project::STATUS_ACTIVE] << ")"
     conditions << " AND ((" << "assigned_to_id = %d" % [user.id] << ")"
     if(user.is_a?(User))

--- a/app/views/settings/_stuff_to_do_settings.html.erb
+++ b/app/views/settings/_stuff_to_do_settings.html.erb
@@ -21,6 +21,13 @@
 </p>
 
 <p>
+  <label><%= l(:stuff_to_do_statuses_available) %></label>
+  <%= select_tag('settings[statuses_for_stuff_to_do]',
+  options_for_select(IssueStatus.where(:is_closed => false).sorted.collect{ |s| [s.name, s.id] }, @settings['statuses_for_stuff_to_do']),
+  :multiple => true) %>
+</p>
+
+<p>
   <label><%= l(:stuff_to_do_use_time_grid) %></label>
   <%= hidden_field_tag 'settings[use_time_grid]', 0 %>
   <%= check_box_tag 'settings[use_time_grid]', 1, @settings['use_time_grid'].to_i == 1 %>

--- a/app/views/settings/_stuff_to_do_settings.html.erb
+++ b/app/views/settings/_stuff_to_do_settings.html.erb
@@ -23,7 +23,7 @@
 <p>
   <label><%= l(:stuff_to_do_statuses_available) %></label>
   <%= select_tag('settings[statuses_for_stuff_to_do]',
-  options_for_select(IssueStatus.where(:is_closed => false).sorted.collect{ |s| [s.name, s.id] }, @settings['statuses_for_stuff_to_do']),
+  options_for_select(IssueStatus.where(:is_closed => false).sorted.collect{ |s| [s.name, s.id] }.unshift(['All Open Statuses', 'all']), @settings['statuses_for_stuff_to_do']),
   :multiple => true) %>
 </p>
 

--- a/app/views/stuff_to_do/_issue.html.erb
+++ b/app/views/stuff_to_do/_issue.html.erb
@@ -9,8 +9,9 @@
           <% else %>
             <%= image_tag('ticket.png') + '#' + h(issue.id) %>
           <% end %>
-          - <%= h(issue.project.name) %> -
-          <%= h(issue.subject) %>
+          - <%= h(issue.project.name) %>
+          - <small><%= h(issue.status.name) %></small>
+          - <%= h(issue.subject) %>
           </div>
   
           <% if issue.estimated_hours && issue.estimated_hours > 0 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
   stuff_to_do_drag_issue_create_list: Drag issues here to create a new list.
   stuff_to_do_drag_issue_remove_list: Drag issues here to remove them from a list.
   stuff_to_do_use_as_stuff_to_do: Use as Stuff To Do items
+  stuff_to_do_statuses_available: Statuses available as Stuff To Do Items
   stuff_to_do_time_grid: "Time Grid"
   stuff_to_do_time_grid_save_error: "{{count}} time entries could not be saved."
   stuff_to_do_time_grid_save_notice: "{{count}} time entries saved."

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,8 @@ Redmine::Plugin.register :stuff_to_do_plugin do
              'use_as_stuff_to_do' => '0',
              'threshold' => '1',
              'email_to' => 'example1@example.com,example2@example.com',
-             'use_time_grid' => '0'
+             'use_time_grid' => '0',
+             'statuses_for_stuff_to_do' => [1]
            })
 
   project_module :stuff_to_do do

--- a/init.rb
+++ b/init.rb
@@ -34,7 +34,7 @@ Redmine::Plugin.register :stuff_to_do_plugin do
              'threshold' => '1',
              'email_to' => 'example1@example.com,example2@example.com',
              'use_time_grid' => '0',
-             'statuses_for_stuff_to_do' => [1]
+             'statuses_for_stuff_to_do' => ['all']
            })
 
   project_module :stuff_to_do do

--- a/lib/stuff_to_do_issue_patch.rb
+++ b/lib/stuff_to_do_issue_patch.rb
@@ -73,7 +73,7 @@ module StuffToDoIssuePatch
     #   be removed
     def update_next_issues
       self.reload
-      StuffToDo.remove_associations_to(self) if self.closed?
+      StuffToDo.remove_associations_to(self) if self.closed? || StuffToDo.unavailable_status?(self)
       StuffToDo.remove_stale_assignments(self)
       return true
     end


### PR DESCRIPTION
Hey @ande3577, just wanted to say thanks for maintaining this repo, we've been using your fork and it's been working great.

We have a lot of custom statuses though, some of which we keep as "open" issues but that are basically finished, so they shouldn't show up as available issues in the Stuff To Do page. So, I added a configuration setting which allows you to select specifically which statuses are available.

The default is "all", which simply lists all open issues, to keep the default current behavior the same.

![screen shot 2013-11-18 at 11 01 57 am](https://f.cloud.github.com/assets/93607/1564098/d2744d4e-506a-11e3-8086-c0367df05a2f.png)
