### PR TITLE
Periodic user mailer

### DIFF
--- a/app/models/stuff_to_do_mailer.rb
+++ b/app/models/stuff_to_do_mailer.rb
@@ -33,4 +33,16 @@ class StuffToDoMailer < Mailer
            format.html
          end
   end
+
+  def periodic_summary(users_stuff_to_dos_hash)
+    @users_stuff_to_dos_hash = users_stuff_to_dos_hash
+    @bypass_user_allowed_to_view = true
+    mail(:to => Setting.plugin_stuff_to_do_plugin['email_to'],
+         :subject => "Stuff To Do Team Summary",
+         :bypass_user_allowed_to_view => @bypass_user_allowed_to_view,
+         :users_stuff_to_do_hash => @users_stuff_to_do_hash) do |format|
+           format.text
+           format.html
+         end
+  end
 end

--- a/app/models/stuff_to_do_mailer.rb
+++ b/app/models/stuff_to_do_mailer.rb
@@ -1,6 +1,7 @@
 #
 
 class StuffToDoMailer < Mailer
+  add_template_helper(StuffToDoHelper)
 
 	default :to => Setting.plugin_stuff_to_do_plugin['email_to']
 	
@@ -19,4 +20,17 @@ class StuffToDoMailer < Mailer
 			format.html 
 		      end
 	end
+
+  def periodic(user, doing_now, recommended)
+    @user = user
+    @doing_now = doing_now
+    @recommended = recommended
+
+    mail(:to => @user.mail,
+         :subject => "Your Stuff To Do",
+         :user => @user) do |format|
+           format.text
+           format.html
+         end
+  end
 end

--- a/app/views/stuff_to_do_mailer/_issue.html.erb
+++ b/app/views/stuff_to_do_mailer/_issue.html.erb
@@ -5,7 +5,7 @@
           </div>
         <% else %>
           <% if @user.allowed_to? :view_issues, issue.project %>
-            <%= link_to(image_tag('ticket.png') + '#' + h(issue.id), :controller => 'issues', :action => 'show', :id => issue) %>
+            <%= link_to(image_tag('ticket.png') + '#' + h(issue.id), issue_url(issue)) %>
           <% else %>
             <%= image_tag('ticket.png') + '#' + h(issue.id) %>
           <% end %>

--- a/app/views/stuff_to_do_mailer/_issue.html.erb
+++ b/app/views/stuff_to_do_mailer/_issue.html.erb
@@ -1,0 +1,25 @@
+      <li class="stuff-to-do-item <%= issue.css_classes if issue.respond_to?(:css_classes) %> <%= issue_counter.odd? ? "odd" : "even" %>" id="stuff_<%= issue.id %>">
+        <div class="issue-details">
+        <% if !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+          <em><%= l(:stuff_to_do_issue_unathorized) %></em>
+          </div>
+        <% else %>
+          <% if @user.allowed_to? :view_issues, issue.project %>
+            <%= link_to(image_tag('ticket.png') + '#' + h(issue.id), :controller => 'issues', :action => 'show', :id => issue) %>
+          <% else %>
+            <%= image_tag('ticket.png') + '#' + h(issue.id) %>
+          <% end %>
+          - <%= h(issue.project.name) %>
+          - <small><%= h(issue.status.name) %></small>
+          - <%= h(issue.subject) %>
+          </div>
+  
+          <% if issue.estimated_hours && issue.estimated_hours > 0 %>
+          <div class="estimate"><%= h(l_hours(issue.estimated_hours)) %> &nbsp;</div>
+          <% end %>
+  
+          <div class="progress"><%= progress_bar(issue.done_ratio, :width => '100%') %></div>
+
+        <% end %>
+        <div style="clear:left;"></div>
+      </li>

--- a/app/views/stuff_to_do_mailer/_issue.html.erb
+++ b/app/views/stuff_to_do_mailer/_issue.html.erb
@@ -1,10 +1,10 @@
       <li class="stuff-to-do-item <%= issue.css_classes if issue.respond_to?(:css_classes) %> <%= issue_counter.odd? ? "odd" : "even" %>" id="stuff_<%= issue.id %>">
         <div class="issue-details">
-        <% if !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+        <% if !@bypass_user_allowed_to_view and !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
           <em><%= l(:stuff_to_do_issue_unathorized) %></em>
           </div>
         <% else %>
-          <% if @user.allowed_to? :view_issues, issue.project %>
+          <% if @bypass_user_allowed_to_view or @user.allowed_to? :view_issues, issue.project %>
             <%= link_to(image_tag('ticket.png') + '#' + h(issue.id), issue_url(issue)) %>
           <% else %>
             <%= image_tag('ticket.png') + '#' + h(issue.id) %>

--- a/app/views/stuff_to_do_mailer/_issue.text.erb
+++ b/app/views/stuff_to_do_mailer/_issue.text.erb
@@ -1,0 +1,10 @@
+<% if !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+  <%= l(:stuff_to_do_issue_unathorized) %>
+<% else %>
+  - <%= h(issue.project.name) %> - <%= h(issue.status.name) %> - <%= h(issue.subject) %>
+  <% if issue.estimated_hours && issue.estimated_hours > 0 %>
+  - <%= h(l_hours(issue.estimated_hours)) %>
+  <% end %>
+  - <%= issue.done_ratio %>
+
+<% end %>

--- a/app/views/stuff_to_do_mailer/_issue.text.erb
+++ b/app/views/stuff_to_do_mailer/_issue.text.erb
@@ -1,4 +1,4 @@
-<% if !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+<% if !@bypass_user_allowed_to_view  and !@user.allowed_to? :view_issues, issue.project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
   <%= l(:stuff_to_do_issue_unathorized) %>
 <% else %>
   - <%= h(issue.project.name) %> - <%= h(issue.status.name) %> - <%= h(issue.subject) %>

--- a/app/views/stuff_to_do_mailer/_item.html.erb
+++ b/app/views/stuff_to_do_mailer/_item.html.erb
@@ -1,0 +1,5 @@
+<% if item.class == Issue %>
+<%= render :partial => 'issue', :locals => {:issue_counter => item_counter}, :object => item %>
+<% else %>
+<%= render :partial => 'project', :locals => {:project_counter => item_counter}, :object => item %>
+<% end %>

--- a/app/views/stuff_to_do_mailer/_item.text.erb
+++ b/app/views/stuff_to_do_mailer/_item.text.erb
@@ -1,0 +1,5 @@
+<% if item.class == Issue %>
+<%= render :partial => 'issue', :locals => {:issue_counter => item_counter}, :object => item %>
+<% else %>
+<%= render :partial => 'project', :locals => {:project_counter => item_counter}, :object => item %>
+<% end %>

--- a/app/views/stuff_to_do_mailer/_project.html.erb
+++ b/app/views/stuff_to_do_mailer/_project.html.erb
@@ -1,10 +1,10 @@
 <li class="stuff-to-do-item project <%= project_counter.odd? ? "odd" : "even" %>" id="stuff_project<%= project.id %>">
 <div class="project-details">      
-<% if !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+<% if !@bypass_user_allowed_to_view and !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
   <em><%= l(:stuff_to_do_project_unathorized) %></em>
   </div>
 <% else %>
-   <% if project.visible?(@user) %>
+   <% if @bypass_user_allowed_to_view or project.visible?(@user) %>
     <%= link_to(image_tag('package.png'), project_url(project)) %>
    <% else %>
     <%= image_tag('package.png') %>

--- a/app/views/stuff_to_do_mailer/_project.html.erb
+++ b/app/views/stuff_to_do_mailer/_project.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% else %>
    <% if project.visible?(@user) %>
-    <%= link_to(image_tag('package.png'), :controller => 'projects', :action => 'show', :id => project) %>
+    <%= link_to(image_tag('package.png'), project_url(project)) %>
    <% else %>
     <%= image_tag('package.png') %>
    <% end %>

--- a/app/views/stuff_to_do_mailer/_project.html.erb
+++ b/app/views/stuff_to_do_mailer/_project.html.erb
@@ -1,0 +1,16 @@
+<li class="stuff-to-do-item project <%= project_counter.odd? ? "odd" : "even" %>" id="stuff_project<%= project.id %>">
+<div class="project-details">      
+<% if !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+  <em><%= l(:stuff_to_do_project_unathorized) %></em>
+  </div>
+<% else %>
+   <% if project.visible?(@user) %>
+    <%= link_to(image_tag('package.png'), :controller => 'projects', :action => 'show', :id => project) %>
+   <% else %>
+    <%= image_tag('package.png') %>
+   <% end %>
+   <%= h project.name %>
+  </div>
+<% end %>
+<div style="clear:left;"></div>
+</li>

--- a/app/views/stuff_to_do_mailer/_project.text.erb
+++ b/app/views/stuff_to_do_mailer/_project.text.erb
@@ -1,0 +1,5 @@
+<% if !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+<%= l(:stuff_to_do_project_unathorized) %>
+<% else %>
+<%= h project.name %>
+<% end %>

--- a/app/views/stuff_to_do_mailer/_project.text.erb
+++ b/app/views/stuff_to_do_mailer/_project.text.erb
@@ -1,4 +1,4 @@
-<% if !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
+<% if !@bypass_user_allowed_to_view and !@user.allowed_to? :view_issues, project and !@user.allowed_to_globally?(:view_all_reportee_stuff_to_do, {}) %>
 <%= l(:stuff_to_do_project_unathorized) %>
 <% else %>
 <%= h project.name %>

--- a/app/views/stuff_to_do_mailer/periodic.html.erb
+++ b/app/views/stuff_to_do_mailer/periodic.html.erb
@@ -1,0 +1,17 @@
+<p>
+Here's your Stuff To Do update!
+</p>
+
+<% if @doing_now %>
+  <h3><%= l(:stuff_to_do_what_im_doing_now) %></h3>
+  <%= render :partial => 'item', :collection => stuff_for(@doing_now) %>
+<% end %>
+
+<% if @recommended %>
+  <h3><%= l(:stuff_to_do_what_is_recommended) %></h3>
+  <%= render :partial => 'item', :collection => stuff_for(@recommended) %>
+<% end %>
+
+<p>
+<%= link_to "View your Stuff To Do", :controller => 'stuff_to_do', :user_id => @user.id, :only_path => false %>
+</p>

--- a/app/views/stuff_to_do_mailer/periodic.text.erb
+++ b/app/views/stuff_to_do_mailer/periodic.text.erb
@@ -1,0 +1,13 @@
+Here's your Stuff To Do update!
+
+<% if @doing_now %>
+<%= l(:stuff_to_do_what_im_doing_now) %>
+<%= render :partial => 'item', :collection => stuff_for(@doing_now) %>
+<% end %>
+
+<% if @recommended %>
+<%= l(:stuff_to_do_what_is_recommended) %>
+<%= render :partial => 'item', :collection => stuff_for(@recommended) %>
+<% end %>
+
+<%= url_for :controller => 'stuff_to_do', :user_id => @user.id, :only_path => false %>

--- a/app/views/stuff_to_do_mailer/periodic_summary.html.erb
+++ b/app/views/stuff_to_do_mailer/periodic_summary.html.erb
@@ -1,0 +1,21 @@
+<p>
+Here's the team's Stuff To Do update!
+</p>
+
+<% @users_stuff_to_dos_hash.each do |user, stuff_to_do| %>
+  <h2><%= user.try(:name) || user.try(:mail) %></h2>
+
+  <% if stuff_to_do[:doing_now] %>
+    <h3><%= l(:stuff_to_do_what_im_doing_now) %></h3>
+    <%= render :partial => 'item', :collection => stuff_for(stuff_to_do[:doing_now]) %>
+  <% end %>
+
+  <% if stuff_to_do[:recommended] %>
+    <h3><%= l(:stuff_to_do_what_is_recommended) %></h3>
+    <%= render :partial => 'item', :collection => stuff_for(stuff_to_do[:recommended]) %>
+  <% end %>
+
+  <p>
+  <%= link_to "View user's Stuff To Do", :controller => 'stuff_to_do', :user_id => user.id, :only_path => false %>
+  </p>
+<% end %>

--- a/app/views/stuff_to_do_mailer/periodic_summary.text.erb
+++ b/app/views/stuff_to_do_mailer/periodic_summary.text.erb
@@ -1,0 +1,17 @@
+Here's the team's Stuff To Do update!
+
+<% @users_stuff_to_dos_hash.each do |user, stuff_to_do| %>
+<%= user.try(:name) || user.try(:mail) %>
+
+<% if stuff_to_do[:doing_now] %>
+<%= l(:stuff_to_do_what_im_doing_now) %>
+<%= render :partial => 'item', :collection => stuff_for(stuff_to_do[:doing_now]) %>
+<% end %>
+
+<% if stuff_to_do[:recommended] %>
+<%= l(:stuff_to_do_what_is_recommended) %>
+<%= render :partial => 'item', :collection => stuff_for(stuff_to_do[:recommended]) %>
+<% end %>
+
+<%= url_for :controller => 'stuff_to_do', :user_id => user.id, :only_path => false %>
+<% end %>

--- a/lib/tasks/stuff_to_do.rake
+++ b/lib/tasks/stuff_to_do.rake
@@ -2,13 +2,16 @@ namespace :redmine do
   namespace :stuff_to_do do
     desc 'Sends periodic StuffToDo mailer'
     task :send_periodic_mailer => :environment do
+      sent = {}
       User.find_each do |user|
         doing_now = StuffToDo.doing_now(user)
         recommended = StuffToDo.recommended(user)
         if doing_now.collect(&:stuff).compact.any? || recommended.collect(&:stuff).compact.any?
+          sent[user] = {:doing_now => doing_now, :recommended => recommended}
           StuffToDoMailer.periodic(user, doing_now, recommended).deliver
         end
       end
+      StuffToDoMailer.periodic_summary(sent).deliver
     end
   end
 end

--- a/lib/tasks/stuff_to_do.rake
+++ b/lib/tasks/stuff_to_do.rake
@@ -1,0 +1,14 @@
+namespace :redmine do
+  namespace :stuff_to_do do
+    desc 'Sends periodic StuffToDo mailer'
+    task :send_periodic_mailer => :environment do
+      User.find_each do |user|
+        doing_now = StuffToDo.doing_now(user)
+        recommended = StuffToDo.recommended(user)
+        if doing_now.collect(&:stuff).compact.any? || recommended.collect(&:stuff).compact.any?
+          StuffToDoMailer.periodic(user, doing_now, recommended).deliver
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We wanted to make the stuff-to-do plugin a bit more active, so we created a mailer that we can schedule to send periodically via the new `rake redmine:stuff_to_do:send_periodic_mailer` rake task. When invoked, it will send a notification email to each user who has stuff to do (it will skip over users who don't have anything set in their `doing_stuff` or `recommended` stuff-to-do queues.
