### PR TITLE
Updated stuff_to_do page format to be consistent with redmine format and styling

### DIFF
--- a/app/views/stuff_to_do/_left_panes.html.erb
+++ b/app/views/stuff_to_do/_left_panes.html.erb
@@ -47,7 +47,7 @@
       </div>
     </div>
 
-    <%= link_to l(:button_clear), url_for(:controller => :stuff_to_do, :action => :clear, :user_id => @user), :confirm => l(:stuff_to_do_clear_confirm) %>
+    <%= link_to l(:button_clear), url_for(:controller => :stuff_to_do, :action => :clear, :user_id => @user), :confirm => l(:stuff_to_do_clear_confirm), :class => 'icon icon-del' %>
   </div>
 
 

--- a/app/views/stuff_to_do/index.html.erb
+++ b/app/views/stuff_to_do/index.html.erb
@@ -1,10 +1,11 @@
 <% html_title(l(:stuff_to_do_title)) %>
-<h1><%= l(:stuff_to_do_title) %></h1>
+<h2><%= l(:stuff_to_do_title) %></h2>
 
 <div id="stuff-to-do-error" class="flash error" style="display:none">
 
 </div>
 
+<fieldset id="filters">
 <div class="menu">
   <% if User.current.allowed_to?(:view_others_stuff_to_do, @project, :global => true) %>
   <div class="user">
@@ -20,12 +21,13 @@
   <div class="filter">
     <%= form_tag({}, :id => 'filter_form') do %>
     <label for="filter"><%= l(:stuff_to_do_label_filter) %></label>
-    <%= select_tag("filter", filter_options(@filters, params[:filter])) %><br>
+    <%= select_tag("filter", filter_options(@filters, params[:filter])) %>
     <label for="project_id"><%= l(:label_project_plural) %></label>
     <%= select_tag("project_id", project_options(StuffToDo.active_and_visible_projects(@user), params[:project_id])) %>
     <% end %>
   </div>
 </div>
+</fieldset>
 <div style="clear:right;"></div>
 
 <%= render :partial => 'panes' %>

--- a/assets/stylesheets/stuff_to_do.css
+++ b/assets/stylesheets/stuff_to_do.css
@@ -4,13 +4,14 @@ ol#available { overflow-y:auto; height: 500px; }
 ol#recommended { overflow-y:auto; height: 300px; }
 li.issue, li.project { cursor: move; }
 li.project { font-weight: bold; }
-div.pane h3 { color: #507AAA; }
+div.pane h3 { margin-top: 20px; }
 span.subtitle { font-size: smaller; color: #CCCCCC }
 div.pane ol { list-style: none; padding-left: 15px;}
 div.pane ol li { padding: 1px 0; }
 div.pane ol li:hover { background-color:#ffffdd; }
 div.pane ol li.empty-list { background-color:#FFFFEE; padding:100px; text-align:center; font-style:italic; }
-div.menu { float:right; text-align: right; }
+div.menu .user { float: left; }
+div.menu .filter { float: right; }
 
 .drop-accepted { background-color:#FFFFEE; height: 16px; width: 100%; border: 1px solid #000000; }
 


### PR DESCRIPTION
There were some things bugging me about the /stuff_to_do page, in that the heading and filters didn't follow the standard redmine page structure for the common elements. It was making the page inconsistent with every other page which uses the standard elements that are styled appropriately by redmine themes.

I also moved the "user" filter to the left side, since it filters who's list you're looking at, which is the left pane. And the other two filters I kept to the right, since they're filtering which issues you can choose from, which are in the right pane.
